### PR TITLE
Declaration file now matches corresponding JS file

### DIFF
--- a/src/plugin.d.ts
+++ b/src/plugin.d.ts
@@ -2,4 +2,4 @@ declare function getCompareSnapshotsPlugin(
   on: Cypress.PluginEvents,
   config: Cypress.PluginConfigOptions,
 ): void;
-export default getCompareSnapshotsPlugin;
+export = getCompareSnapshotsPlugin;


### PR DESCRIPTION
The current version allows importing as if the source code provided a default, producing no TS error even when the `esModuleInterop` is not enabled. Furthermore, it prevents scenarios that to consume the commonjs directly via require from type checking