### PR TITLE
Remove image timestamps

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -21,7 +21,11 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
           (defaultScreenshotOptions &&
             defaultScreenshotOptions.errorThreshold) ||
           0.0;
-        screenshotOptions = Object.assign({}, defaultScreenshotOptions, params);
+        screenshotOptions = Object.assign(
+          { overwrite: true },
+          defaultScreenshotOptions,
+          params
+        );
       }
       let title = 'actual';
       if (Cypress.env('type') === 'base') {
@@ -31,19 +35,8 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
       // take snapshot
       const objToOperateOn = subject ? cy.get(subject) : cy;
       const fileName = `${name}-${title}`;
-      if (Cypress.env('type') === 'base') {
-        const identifier = `${fileName}-${new Date().getTime()}`;
-        objToOperateOn
-          .screenshot(`${identifier}`, screenshotOptions)
-          .task('visualRegressionCopy', {
-            specName: Cypress.spec.name,
-            from: `${identifier}`,
-            to: `${fileName}`,
-            baseDir: SNAPSHOT_BASE_DIRECTORY,
-          });
-      } else {
-        objToOperateOn.screenshot(`${fileName}`, screenshotOptions);
-      }
+
+      objToOperateOn.screenshot(`${fileName}`, screenshotOptions);
 
       // run visual tests
       if (Cypress.env('type') === 'actual') {

--- a/src/command.js
+++ b/src/command.js
@@ -36,7 +36,15 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
       const objToOperateOn = subject ? cy.get(subject) : cy;
       const fileName = `${name}-${title}`;
 
-      objToOperateOn.screenshot(`${fileName}`, screenshotOptions);
+      if (Cypress.env('type') === 'base') {
+        const baseFilePath = path.join(
+          SNAPSHOT_BASE_DIRECTORY,
+          `${fileName}.png`
+        );
+        objToOperateOn.screenshot(baseFilePath, screenshotOptions);
+      } else {
+        objToOperateOn.screenshot(`${fileName}`, screenshotOptions);
+      }
 
       // run visual tests
       if (Cypress.env('type') === 'actual') {


### PR DESCRIPTION
This removes timestamped duplicates from base images as mentioned in issues #111 and #76. This also sets the default overwrite to "true" for actual photos.