### PR TITLE
Fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cypress-visual-regression",
   "version": "1.7.0",
   "description": "Module for adding visual regression testing to Cypress",
-  "repository": "https://github.com/mjhea0/cypress-visual-regression",
+  "repository": "https://github.com/cypress-visual-regression/cypress-visual-regression",
   "author": "Michael Herman <michael@mherman.org>",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Hi there, as always, thanks for this package, very useful! 🙌

Quick PR to fix the "Repository" and "Homepage" on the right column of the npm website pointing at the old location https://github.com/mjhea0/cypress-visual-regression:

![Screenshot 2022-12-10 at 10 47 22](https://user-images.githubusercontent.com/1935696/206846214-48e123ad-c312-4dba-bb7e-f6fa26967cd7.png)
