### PR TITLE
Prevent implicit dependency to fs in command.js

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -1,5 +1,4 @@
-const { deserializeError } = require('./utils-browser');
-const { getValueOrDefault } = require('./utils');
+const { deserializeError, getValueOrDefault } = require('./utils-browser');
 
 /* eslint-disable no-undef */
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -11,8 +11,8 @@ const {
   createFolder,
   parseImage,
   errorSerialize,
-  getValueOrDefault,
 } = require('./utils');
+const { getValueOrDefault } = require('./utils-browser');
 
 let CYPRESS_SCREENSHOT_DIR;
 

--- a/src/utils-browser.js
+++ b/src/utils-browser.js
@@ -10,4 +10,6 @@ class CompareSnapshotsPluginError extends Error {
 const deserializeError = (error) =>
   new CompareSnapshotsPluginError(JSON.parse(error));
 
-module.exports = { deserializeError };
+const getValueOrDefault = (value, defaultValue) => value || defaultValue;
+
+module.exports = { deserializeError, getValueOrDefault };

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,13 +79,10 @@ const errorSerialize = (error) =>
     )
   );
 
-const getValueOrDefault = (value, defaultValue) => value || defaultValue;
-
 module.exports = {
   adjustCanvas,
   createFolder,
   mkdirp,
   parseImage,
   errorSerialize,
-  getValueOrDefault,
 };


### PR DESCRIPTION
This removes an implicit dependency of `command.js` to the `fs` module which is not available in the browser and caused #156. I just moved the `getValueOrDefault` function from `utils.js` to `utils-browser.js` and imported it accordingly in `plugin.js` and `command.js`. Closes #156 for me.