### PR TITLE
add option to combine actual/diff/expected images side by side

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -108,8 +108,8 @@ async function compareSnapshotsPlugin(args) {
     await createFolder(snapshotDiffDirectory, args.failSilently);
     const imgExpected = await parseImage(options.expectedImage);
     const imgActual = await parseImage(options.actualImage);
-    let diffWidth = Math.max(imgActual.width, imgExpected.width);
-    let diffHeight = Math.max(imgActual.height, imgExpected.height);
+    const diffWidth = Math.max(imgActual.width, imgExpected.width);
+    const  diffHeight = Math.max(imgActual.height, imgExpected.height);
 
     const diff = new PNG({
       width: diffWidth,

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -64,7 +64,6 @@ async function updateSnapshot(args) {
     .then(() => null);
 }
 
-
 /** Cypress plugin to compare image snapshots & generate a diff image.
  *
  * Uses the pixelmatch library internally.
@@ -109,7 +108,7 @@ async function compareSnapshotsPlugin(args) {
     const imgExpected = await parseImage(options.expectedImage);
     const imgActual = await parseImage(options.actualImage);
     const diffWidth = Math.max(imgActual.width, imgExpected.width);
-    const  diffHeight = Math.max(imgActual.height, imgExpected.height);
+    const diffHeight = Math.max(imgActual.height, imgExpected.height);
 
     const diff = new PNG({
       width: diffWidth,

--- a/src/utils.js
+++ b/src/utils.js
@@ -81,6 +81,7 @@ const errorSerialize = (error) =>
 
 module.exports = {
   adjustCanvas,
+  combineImages,
   createFolder,
   mkdirp,
   parseImage,

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,15 +79,6 @@ const errorSerialize = (error) =>
     )
   );
 
-module.exports = {
-  adjustCanvas,
-  combineImages,
-  createFolder,
-  mkdirp,
-  parseImage,
-  errorSerialize,
-};
-
 // Combines 3 images side by side
 // Courtesy of ChatGPT!
 const combineImages = async (file1, file2, file3, output) => {
@@ -128,3 +119,12 @@ const combineImages = async (file1, file2, file3, output) => {
     combinedImg.pack().pipe(stream);
   });
 }
+
+module.exports = {
+  adjustCanvas,
+  combineImages,
+  createFolder,
+  mkdirp,
+  parseImage,
+  errorSerialize,
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -86,3 +86,44 @@ module.exports = {
   parseImage,
   errorSerialize,
 };
+
+// Combines 3 images side by side
+// Courtesy of ChatGPT!
+const combineImages = async (file1, file2, file3, output) => {
+  const [img1, img2, img3] = await Promise.all([
+    new Promise((resolve, reject) => {
+      fs.createReadStream(file1)
+        .pipe(new PNG())
+        .on('error', reject)
+        .on('parsed', () => resolve(this));
+    }),
+    new Promise((resolve, reject) => {
+      fs.createReadStream(file2)
+        .pipe(new PNG())
+        .on('error', reject)
+        .on('parsed', () => resolve(this));
+    }),
+    new Promise((resolve, reject) => {
+      fs.createReadStream(file3)
+        .pipe(new PNG())
+        .on('error', reject)
+        .on('parsed', () => resolve(this));
+    })
+  ]);
+
+  const combinedImg = new PNG({
+    width: img1.width + img2.width + img3.width,
+    height: Math.max(img1.height, img2.height, img3.height)
+  });
+
+  img1.bitblt(combinedImg, 0, 0, img1.width, img1.height, 0, 0);
+  img2.bitblt(combinedImg, 0, 0, img2.width, img2.height, img1.width, 0);
+  img3.bitblt(combinedImg, 0, 0, img3.width, img3.height, img1.width + img2.width, 0);
+
+  const stream = fs.createWriteStream(output);
+  await new Promise((resolve, reject) => {
+    stream.on('error', reject);
+    stream.on('close', resolve);
+    combinedImg.pack().pipe(stream);
+  });
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -100,17 +100,25 @@ const combineImages = async (file1, file2, file3, output) => {
         .pipe(new PNG())
         .on('error', reject)
         .on('parsed', () => resolve(this));
-    })
+    }),
   ]);
 
   const combinedImg = new PNG({
     width: img1.width + img2.width + img3.width,
-    height: Math.max(img1.height, img2.height, img3.height)
+    height: Math.max(img1.height, img2.height, img3.height),
   });
 
   img1.bitblt(combinedImg, 0, 0, img1.width, img1.height, 0, 0);
   img2.bitblt(combinedImg, 0, 0, img2.width, img2.height, img1.width, 0);
-  img3.bitblt(combinedImg, 0, 0, img3.width, img3.height, img1.width + img2.width, 0);
+  img3.bitblt(
+    combinedImg,
+    0,
+    0,
+    img3.width,
+    img3.height,
+    img1.width + img2.width,
+    0
+  );
 
   const stream = fs.createWriteStream(output);
   await new Promise((resolve, reject) => {
@@ -118,7 +126,7 @@ const combineImages = async (file1, file2, file3, output) => {
     stream.on('close', resolve);
     combinedImg.pack().pipe(stream);
   });
-}
+};
 
 module.exports = {
   adjustCanvas,


### PR DESCRIPTION
I'm trying to debug a failing test and I think this might make it easier to tell what is going on, instead of just using the diff alone

This would fix https://github.com/cypress-visual-regression/cypress-visual-regression/issues/132