### PR TITLE
Remove file name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,6 @@ For more info on how to use TypeScript with Cypress, please refer to [this docum
 
 ### Options
 
-`REMOVE_SUFFIX` is set to `false` by default. This means that generated images will be suffixed with `-base`, `-actual` or `-diff`.
-
-If you want to remove the suffixes you can set `REMOVE_SUFFIX` to `true` in your *cypress.config.js* file:
-
-```javascript
-{
-  env: {
-    REMOVE_SUFFIX: true
-  }
-}
-```
-
-
 `failSilently` is enabled by default. Add the following config to your *cypress.config.js* file to see the errors:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -99,6 +99,19 @@ For more info on how to use TypeScript with Cypress, please refer to [this docum
 
 ### Options
 
+`REMOVE_SUFFIX` is set to `false` by default. This means that generated images will be suffixed with `-base`, `-actual` or `-diff`.
+
+If you want to remove the suffixes you can set `REMOVE_SUFFIX` to `true` in your *cypress.config.js* file:
+
+```javascript
+{
+  env: {
+    REMOVE_SUFFIX: true
+  }
+}
+```
+
+
 `failSilently` is enabled by default. Add the following config to your *cypress.config.js* file to see the errors:
 
 ```javascript
@@ -144,7 +157,7 @@ typically set by using the field `env` in configuration in `cypress.config.json`
 | ALLOW_VISUAL_REGRESSION_TO_FAIL | Boolean, defaults to false |
 
 
-`ALWAYS_GENERATE_DIFF` specifies if diff images are generated for successful tests.  
+`ALWAYS_GENERATE_DIFF` specifies if diff images are generated for successful tests.
 If you only want the tests to create diff images based on your threshold without the tests to fail, you can set `ALLOW_VISUAL_REGRESSION_TO_FAIL`.
 If this variable is set, diffs will be computed using your thresholds but tests will not fail if a diff is found.
 
@@ -241,7 +254,7 @@ function beforeCompareSnapshotCommand(
 ) {
   Cypress.Commands.overwrite("compareSnapshot", (originalFn, ...args) => {
     return cy
-      // wait for content to be ready 
+      // wait for content to be ready
       .get(appContentQuerySelector)
       // hide ignored elements
       .then($app => {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 # base image
-FROM cypress/browsers:node14.16.0-chrome90-ff88
+FROM cypress/browsers:node16.16.0-chrome107-ff107
 
 # set variables
-ARG CYPRESS_VERSION=10.11.0
+ARG CYPRESS_VERSION=12.7.0
 ENV SNAPSHOT_DIRECTORY /usr/src/app/cypress/snapshots
 ENV CI true
 RUN echo ${CYPRESS_VERSION}

--- a/docker/cypress.config.js
+++ b/docker/cypress.config.js
@@ -11,9 +11,7 @@ module.exports = defineConfig({
       getCompareSnapshotsPlugin(on, config);
 
       on("task", {
-        doesExist: path => {
-          return fs.existsSync(path);
-        }
+        doesExist: path => fs.existsSync(path)
       })
     },
   },

--- a/docker/cypress/e2e/main.cy.js
+++ b/docker/cypress/e2e/main.cy.js
@@ -1,4 +1,5 @@
 describe('Visual Regression Example', () => {
+
   it('should display the home page correctly', () => {
     cy.visit('../../web/01.html');
     cy.get('H1').contains('Hello, World');
@@ -12,8 +13,8 @@ describe('Visual Regression Example', () => {
         expect($error).to.be.a('string');
         const json = JSON.parse($error);
         expect(json).to.be.a('object');
-        expect(json.message).to.eq('Snapshot /usr/src/app/cypress/snapshots/base/main.cy.js/missing-base.png does not exist.');
-        expect(json.stack).to.include('Error: Snapshot /usr/src/app/cypress/snapshots/base/main.cy.js/missing-base.png does not exist.\n    at /usr/src/app/dist/utils.js');
+        expect(json.message).to.eq('Snapshot /usr/src/app/cypress/snapshots/base/main.cy.js/missing.png does not exist.');
+        expect(json.stack).to.include('Error: Snapshot /usr/src/app/cypress/snapshots/base/main.cy.js/missing.png does not exist.\n    at /usr/src/app/dist/utils.js');
       });
     };
   });
@@ -145,4 +146,5 @@ describe('Visual Regression Example', () => {
       cy.get('H1').compareSnapshotTest('h1', 0.07).should('be.false');
     }
   });
+
 });

--- a/docker/cypress/e2e/main.env.cy.js
+++ b/docker/cypress/e2e/main.env.cy.js
@@ -30,3 +30,26 @@ describe('Visual Regression Example with setting paths by environment variables'
     }
   });
 });
+
+describe('Visual Regression Example with setting paths by environment variables', {
+  env: {
+    REMOVE_SUFFIX: true
+  }
+},() => {
+  it('take screenshot with parent command', () => {
+    if (Cypress.env('type') === 'base') {
+      cy.visit('../../web/01.html');
+      cy.get('H1').contains('Hello, World');
+      cy.compareSnapshot('home');
+    }
+    else {
+      cy.visit('../../web/01.html');
+      cy.get('H1').contains('Hello, World');
+      cy.compareSnapshot('home');
+      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home.png").should("be.true");
+    }
+
+  });
+});

--- a/docker/cypress/e2e/main.env.cy.js
+++ b/docker/cypress/e2e/main.env.cy.js
@@ -11,9 +11,9 @@ describe('Visual Regression Example with setting paths by environment variables'
       cy.visit('../../web/01.html');
       cy.get('H1').contains('Hello, World');
       cy.compareSnapshot('home');
-      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home-base.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home-diff.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home-actual.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home.png").should("be.true");
     }
   });
 
@@ -24,32 +24,9 @@ describe('Visual Regression Example with setting paths by environment variables'
     } else {
       cy.visit('../../web/01.html');
       cy.get('H1').contains('Hello, World').compareSnapshot('home-child');
-      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home-child-base.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home-child-diff.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home-child-actual.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home-child.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home-child.png").should("be.true");
+      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home-child.png").should("be.true");
     }
-  });
-});
-
-describe('Visual Regression Example with setting paths by environment variables', {
-  env: {
-    REMOVE_SUFFIX: true
-  }
-},() => {
-  it('take screenshot with parent command', () => {
-    if (Cypress.env('type') === 'base') {
-      cy.visit('../../web/01.html');
-      cy.get('H1').contains('Hello, World');
-      cy.compareSnapshot('home');
-    }
-    else {
-      cy.visit('../../web/01.html');
-      cy.get('H1').contains('Hello, World');
-      cy.compareSnapshot('home');
-      cy.task("doesExist", "./cypress/snapshots/base/main.env.cy.js/home.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/diff/main.env.cy.js/home.png").should("be.true");
-      cy.task("doesExist", "./cypress/snapshots/actual/main.env.cy.js/home.png").should("be.true");
-    }
-
   });
 });

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -1,15 +1,6 @@
 const path = require('path');
 const compareSnapshotCommand = require('../../dist/command.js');
 
-function getSuffix (type,removeSuffix ) {
-  if (removeSuffix) {
-    return ''
-  } if (type === 'base') {
-      return '-base'
-  }
-    return '-actual'
-}
-
 function compareSnapshotTestCommand() {
   Cypress.Commands.add('compareSnapshotTest', { prevSubject: 'optional' }, (subject, name, params = 0.0) => {
     let screenshotOptions = {};
@@ -21,14 +12,13 @@ function compareSnapshotTestCommand() {
       // eslint-disable-next-line prefer-object-spread
       screenshotOptions = Object.assign({}, params);
     }
-    const suffix = getSuffix(Cypress.env('type'), Cypress.env('REMOVE_SUFFIX'))
 
     const specDirectory = Cypress.spec.relative.replace('cypress/e2e', '');
     // take snapshot
     if (subject) {
-      cy.get(subject).screenshot(`${name}${suffix}`, screenshotOptions);
+      cy.get(subject).screenshot(`${name}`, screenshotOptions);
     } else {
-      cy.screenshot(`${name}${suffix}`, screenshotOptions);
+      cy.screenshot(`${name}`, screenshotOptions);
     }
 
     // run visual tests

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -16,9 +16,9 @@ function compareSnapshotTestCommand() {
     const specDirectory = Cypress.spec.relative.replace('cypress/e2e', '');
     // take snapshot
     if (subject) {
-      cy.get(subject).screenshot(`${name}`, screenshotOptions);
+      cy.get(subject).screenshot(name, screenshotOptions);
     } else {
-      cy.screenshot(`${name}`, screenshotOptions);
+      cy.screenshot(name, screenshotOptions);
     }
 
     // run visual tests

--- a/docker/cypress/support/commands.js
+++ b/docker/cypress/support/commands.js
@@ -1,5 +1,14 @@
-const compareSnapshotCommand = require('../../dist/command.js');
 const path = require('path');
+const compareSnapshotCommand = require('../../dist/command.js');
+
+function getSuffix (type,removeSuffix ) {
+  if (removeSuffix) {
+    return ''
+  } if (type === 'base') {
+      return '-base'
+  }
+    return '-actual'
+}
 
 function compareSnapshotTestCommand() {
   Cypress.Commands.add('compareSnapshotTest', { prevSubject: 'optional' }, (subject, name, params = 0.0) => {
@@ -12,27 +21,21 @@ function compareSnapshotTestCommand() {
       // eslint-disable-next-line prefer-object-spread
       screenshotOptions = Object.assign({}, params);
     }
-    // get image title from the 'type' environment variable
-    let title = 'actual';
-    if (Cypress.env('type') === 'base') {
-      title = 'base';
-    }
+    const suffix = getSuffix(Cypress.env('type'), Cypress.env('REMOVE_SUFFIX'))
 
     const specDirectory = Cypress.spec.relative.replace('cypress/e2e', '');
-    const screenshotPath = path.join(specDirectory, `${name}-${title}`);
-
     // take snapshot
     if (subject) {
-      cy.get(subject).screenshot(`${name}-${title}`, screenshotOptions);
+      cy.get(subject).screenshot(`${name}${suffix}`, screenshotOptions);
     } else {
-      cy.screenshot(`${name}-${title}`, screenshotOptions);
+      cy.screenshot(`${name}${suffix}`, screenshotOptions);
     }
 
     // run visual tests
     if (Cypress.env('type') === 'actual') {
       const options = {
         fileName: name,
-        specDirectory: specDirectory,
+        specDirectory,
         failSilently: Cypress.env('failSilently') !== undefined ? Cypress.env('failSilently') : true
       };
       cy.task('compareSnapshotsPlugin', options).then(results => {

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "cypress": "^12.8.1",
     "cypress-visual-regression": "1.7.0",
     "pixelmatch": "5.2.1",
     "pngjs": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-visual-regression",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-visual-regression",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "pixelmatch": "^5.2.1",

--- a/src/command.js
+++ b/src/command.js
@@ -34,16 +34,14 @@ function takeScreenshot(subject, name, screenshotOptions) {
     screenshotPath = props.path;
   }
 
-  const suffixActual = Cypress.env('REMOVE_SUFFIX') ? '' : '-actual';
-
   objToOperateOn
-    .screenshot(`${name}${suffixActual}`, {
+    .screenshot(name, {
       ...screenshotOptions,
       onAfterScreenshot,
     })
     .then(() => {
       cy.task('moveSnapshot', {
-        fileName: `${name}${suffixActual}.png`,
+        fileName: `${name}.png`,
         fromPath: screenshotPath,
         specDirectory: getSpecRelativePath(),
       });
@@ -56,7 +54,6 @@ function updateScreenshot(name) {
     specDirectory: getSpecRelativePath(),
     screenshotsFolder: Cypress.config().screenshotsFolder,
     snapshotBaseDirectory: Cypress.env('SNAPSHOT_BASE_DIRECTORY'),
-    removeSuffix: Cypress.env('REMOVE_SUFFIX'),
   });
 }
 
@@ -68,7 +65,6 @@ function compareScreenshots(name, errorThreshold) {
     baseDir: Cypress.env('SNAPSHOT_BASE_DIRECTORY'),
     diffDir: Cypress.env('SNAPSHOT_DIFF_DIRECTORY'),
     keepDiff: Cypress.env('ALWAYS_GENERATE_DIFF'),
-    removeSuffix: Cypress.env('REMOVE_SUFFIX'),
     allowVisualRegressionToFail: Cypress.env('ALLOW_VISUAL_REGRESSION_TO_FAIL'),
     errorThreshold,
   };

--- a/src/command.js
+++ b/src/command.js
@@ -34,11 +34,16 @@ function takeScreenshot(subject, name, screenshotOptions) {
     screenshotPath = props.path;
   }
 
+  const suffixActual = Cypress.env('REMOVE_SUFFIX') ? '' : '-actual';
+
   objToOperateOn
-    .screenshot(`${name}-actual`, { ...screenshotOptions, onAfterScreenshot })
+    .screenshot(`${name}${suffixActual}`, {
+      ...screenshotOptions,
+      onAfterScreenshot,
+    })
     .then(() => {
       cy.task('moveSnapshot', {
-        fileName: `${name}-actual.png`,
+        fileName: `${name}${suffixActual}.png`,
         fromPath: screenshotPath,
         specDirectory: getSpecRelativePath(),
       });
@@ -51,6 +56,7 @@ function updateScreenshot(name) {
     specDirectory: getSpecRelativePath(),
     screenshotsFolder: Cypress.config().screenshotsFolder,
     snapshotBaseDirectory: Cypress.env('SNAPSHOT_BASE_DIRECTORY'),
+    removeSuffix: Cypress.env('REMOVE_SUFFIX'),
   });
 }
 
@@ -62,6 +68,7 @@ function compareScreenshots(name, errorThreshold) {
     baseDir: Cypress.env('SNAPSHOT_BASE_DIRECTORY'),
     diffDir: Cypress.env('SNAPSHOT_DIFF_DIRECTORY'),
     keepDiff: Cypress.env('ALWAYS_GENERATE_DIFF'),
+    removeSuffix: Cypress.env('REMOVE_SUFFIX'),
     allowVisualRegressionToFail: Cypress.env('ALLOW_VISUAL_REGRESSION_TO_FAIL'),
     errorThreshold,
   };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,6 +16,18 @@ const { getValueOrDefault } = require('./utils-browser');
 
 let CYPRESS_SCREENSHOT_DIR;
 
+function suffixActual(removeSuffix) {
+  return removeSuffix ? '' : '-actual';
+}
+
+function suffixBase(removeSuffix) {
+  return removeSuffix ? '' : '-base';
+}
+
+function suffixDiff(removeSuffix) {
+  return removeSuffix ? '' : '-diff';
+}
+
 function setupScreenshotPath(config) {
   // use cypress default path as fallback
   CYPRESS_SCREENSHOT_DIR = getValueOrDefault(
@@ -39,8 +51,13 @@ async function moveSnapshot(args) {
 /** Update the base snapshot .png by copying the generated snapshot to the base snapshot directory.
  * The target path is constructed from parts at runtime in node to be OS independent.  */
 async function updateSnapshot(args) {
-  const { name, screenshotsFolder, snapshotBaseDirectory, specDirectory } =
-    args;
+  const {
+    name,
+    screenshotsFolder,
+    snapshotBaseDirectory,
+    specDirectory,
+    removeSuffix,
+  } = args;
   const toDir = getValueOrDefault(
     snapshotBaseDirectory,
     path.join(process.cwd(), 'cypress', 'snapshots', 'base')
@@ -54,9 +71,10 @@ async function updateSnapshot(args) {
   const fromPath = path.join(
     snapshotActualDirectory,
     specDirectory,
-    `${name}-actual.png`
+    `${name}${suffixActual(removeSuffix)}.png`
   );
-  const destFile = path.join(destDir, `${name}-base.png`);
+
+  const destFile = path.join(destDir, `${name}${suffixBase(removeSuffix)}.png`);
 
   return createFolder(destDir, false)
     .then(() => fsp.copyFile(fromPath, destFile))
@@ -85,17 +103,17 @@ async function compareSnapshotsPlugin(args) {
     actualImage: path.join(
       CYPRESS_SCREENSHOT_DIR,
       args.specDirectory,
-      `${fileName}-actual.png`
+      `${fileName}${suffixActual(args.removeSuffix)}.png`
     ),
     expectedImage: path.join(
       snapshotBaseDirectory,
       args.specDirectory,
-      `${fileName}-base.png`
+      `${fileName}${suffixBase(args.removeSuffix)}.png`
     ),
     diffImage: path.join(
       snapshotDiffDirectory,
       args.specDirectory,
-      `${fileName}-diff.png`
+      `${fileName}${suffixDiff(args.removeSuffix)}.png`
     ),
   };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,18 +16,6 @@ const { getValueOrDefault } = require('./utils-browser');
 
 let CYPRESS_SCREENSHOT_DIR;
 
-function suffixActual(removeSuffix) {
-  return removeSuffix ? '' : '-actual';
-}
-
-function suffixBase(removeSuffix) {
-  return removeSuffix ? '' : '-base';
-}
-
-function suffixDiff(removeSuffix) {
-  return removeSuffix ? '' : '-diff';
-}
-
 function setupScreenshotPath(config) {
   // use cypress default path as fallback
   CYPRESS_SCREENSHOT_DIR = getValueOrDefault(
@@ -51,13 +39,8 @@ async function moveSnapshot(args) {
 /** Update the base snapshot .png by copying the generated snapshot to the base snapshot directory.
  * The target path is constructed from parts at runtime in node to be OS independent.  */
 async function updateSnapshot(args) {
-  const {
-    name,
-    screenshotsFolder,
-    snapshotBaseDirectory,
-    specDirectory,
-    removeSuffix,
-  } = args;
+  const { name, screenshotsFolder, snapshotBaseDirectory, specDirectory } =
+    args;
   const toDir = getValueOrDefault(
     snapshotBaseDirectory,
     path.join(process.cwd(), 'cypress', 'snapshots', 'base')
@@ -71,10 +54,10 @@ async function updateSnapshot(args) {
   const fromPath = path.join(
     snapshotActualDirectory,
     specDirectory,
-    `${name}${suffixActual(removeSuffix)}.png`
+    `${name}.png`
   );
 
-  const destFile = path.join(destDir, `${name}${suffixBase(removeSuffix)}.png`);
+  const destFile = path.join(destDir, `${name}.png`);
 
   return createFolder(destDir, false)
     .then(() => fsp.copyFile(fromPath, destFile))
@@ -103,17 +86,17 @@ async function compareSnapshotsPlugin(args) {
     actualImage: path.join(
       CYPRESS_SCREENSHOT_DIR,
       args.specDirectory,
-      `${fileName}${suffixActual(args.removeSuffix)}.png`
+      `${fileName}.png`
     ),
     expectedImage: path.join(
       snapshotBaseDirectory,
       args.specDirectory,
-      `${fileName}${suffixBase(args.removeSuffix)}.png`
+      `${fileName}.png`
     ),
     diffImage: path.join(
       snapshotDiffDirectory,
       args.specDirectory,
-      `${fileName}${suffixDiff(args.removeSuffix)}.png`
+      `${fileName}.png`
     ),
   };
 


### PR DESCRIPTION
## Context

Right now images generated by this plugin will prepend a string to their names accordingly to `-base`, `-actual`, or `-diff`, and there is no possibility not to prepend the file names.

With this PR I'm adding a new env var `REMOVE_SUFFIX` to allow the user to not use a suffix on images names.
 

### Motivation of the change

The motivation for this change is for us to use the images with the same name since they are already saved in different directories.

With this change, we can generate the images and use them with a reporter library tool like [reg-cli](https://github.com/reg-viz/reg-cli) to generate a report with the changes on the images 

```bash
reg-cli ./cypress/screenshots ./cypress/base ./cypress/_diff -R ./report.html
```

You can see an example of the tool and what you can get just by having the images generated (base, actual and diffs) with the same name 
https://reg-viz.github.io/reg-cli/

With this MR we will also solve open PR https://github.com/cypress-visual-regression/cypress-visual-regression/pull/170, 
and will give a solution to this issue https://github.com/cypress-visual-regression/cypress-visual-regression/issues/132