### PR TITLE
Fix export for ESM and module: Node16

### DIFF
--- a/src/command.d.ts
+++ b/src/command.d.ts
@@ -12,4 +12,6 @@ declare global {
   }
 }
 
-export default function compareSnapshotCommand(options?: Partial<Cypress.ScreenshotOptions | CompareSnapshotOptions>): void;
+declare function compareSnapshotCommand(options?: Partial<Cypress.ScreenshotOptions | CompareSnapshotOptions>): void;
+
+export = compareSnapshotCommand;

--- a/src/plugin.d.ts
+++ b/src/plugin.d.ts
@@ -2,4 +2,4 @@ declare function getCompareSnapshotsPlugin(
   on: Cypress.PluginEvents,
   config: Cypress.PluginConfigOptions,
 ): void;
-export default getCompareSnapshotsPlugin;
+export = getCompareSnapshotsPlugin;


### PR DESCRIPTION
Fixes the `This expression is not callable` error with ESM (eg. `"type": "module"` in `package.json`) and modern Node.js module resolution (`"module": "Node16"` or `"module": "NodeNext"` in `tsconfig.json`):

[Playground](https://www.typescriptlang.org/play?target=99&moduleResolution=99&module=100#code/JYWwDg9gTgLgBAcgMYE8xQKYGcsFoBuwWArgIYA2umA5pjsBAHYIDcAUKJLHEhOKZgDKjUmCwALCDADCfEKUYATOADMofRKnTY8hEhSoZaOhowD0iojDO8Q8pQDoAVllZt3Hj7bACMw0RJSsnYKigAUAJQsQA)

```
This expression is not callable.
  Type 'typeof import("file:///node_modules/cypress-visual-regression/dist/command")' has no call signatures.(2349)
```

![Screenshot 2023-04-16 at 19 17 56](https://user-images.githubusercontent.com/1935696/232329829-820e4dd5-8f60-4102-b21c-37cd716ad909.png)
