### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ import { defineConfig } from 'cypress';
 import getCompareSnapshotsPlugin from 'cypress-visual-regression/dist/plugin';
 
 export default defineConfig({
-  env: {
-    screenshotsFolder: './cypress/snapshots/actual',
-    trashAssetsBeforeRuns: true,
-    video: false
-  },
+  screenshotsFolder: './cypress/snapshots/actual',
+  trashAssetsBeforeRuns: true,
+  video: false,
   e2e: {
     setupNodeEvents(on, config) {
       getCompareSnapshotsPlugin(on, config);


### PR DESCRIPTION
The example config for TypeScript incorrectly nested three options inside the `env` object.