### PR TITLE
Add new `skipDiff` arg to `compareScreenshots`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,15 @@ typically set by using the field `env` in configuration in `cypress.config.json`
 | Variable                        | Description                  |
 |---------------------------------|------------------------------|
 | ALWAYS_GENERATE_DIFF            | Boolean, defaults to `true`  |
+| NEVER_GENERATE_DIFF             | Boolean, defaults to `false` |
 | ALLOW_VISUAL_REGRESSION_TO_FAIL | Boolean, defaults to `false` |
 
 
 `ALWAYS_GENERATE_DIFF` specifies if diff images are generated for successful tests.
 If you only want the tests to create diff images based on your threshold without the tests to fail, you can set `ALLOW_VISUAL_REGRESSION_TO_FAIL`.
 If this variable is set, diffs will be computed using your thresholds but tests will not fail if a diff is found.
+`NEVER_GENERATE_DIFF` specifies if diff images should never be created regardless of
+the test result.
 
 If you want to see all diff images which are different (based on your thresholds), use the following in your `cypress.config.json`:
 ```json
@@ -196,6 +199,21 @@ it('should display the login page correctly', () => {
   cy.compareSnapshot('login', {
     capture: 'fullPage',
     errorThreshold: 0.1
+  });
+});
+```
+
+```js
+
+let retryAttempt = 0
+
+it('should display the user profile page correctly', {retries: {runMode: 3}}, () => {
+  cy.visit('/05.html'); // assuming async load of page content
+  cy.wait(50); // 50ms between retry attempts
+  cy.compareSnapshot('user-profile', {
+    capture: 'viewport',
+    errorThreshold: 0,
+    skipDiff: ++retryAttempt < 3 // create diff only for last retry attempt
   });
 });
 ```

--- a/src/command.d.ts
+++ b/src/command.d.ts
@@ -1,5 +1,8 @@
 interface CompareSnapshotOptions {
   errorThreshold: number;
+  keepDiff: boolean;
+  skipDiff: boolean;
+  allowVisualRegressionToFail: boolean;
 }
 
 declare global {

--- a/src/command.js
+++ b/src/command.js
@@ -59,14 +59,20 @@ function updateScreenshot(name) {
 }
 
 /** Call the plugin to compare snapshot images and generate a diff */
-function compareScreenshots(name, errorThreshold) {
+function compareScreenshots(
+  name,
+  { errorThreshold, keepDiff, skipDiff, allowVisualRegressionToFail }
+) {
   const options = {
     fileName: name,
     specDirectory: getSpecRelativePath(),
     baseDir: Cypress.env('SNAPSHOT_BASE_DIRECTORY'),
     diffDir: Cypress.env('SNAPSHOT_DIFF_DIRECTORY'),
-    keepDiff: Cypress.env('ALWAYS_GENERATE_DIFF'),
-    allowVisualRegressionToFail: Cypress.env('ALLOW_VISUAL_REGRESSION_TO_FAIL'),
+    keepDiff: keepDiff || Cypress.env('ALWAYS_GENERATE_DIFF'),
+    skipDiff: skipDiff || Cypress.env('NEVER_GENERATE_DIFF'),
+    allowVisualRegressionToFail:
+      allowVisualRegressionToFail ||
+      Cypress.env('ALLOW_VISUAL_REGRESSION_TO_FAIL'),
     errorThreshold,
   };
 
@@ -93,10 +99,10 @@ function compareSnapshotCommand(defaultScreenshotOptions) {
 
       switch (type) {
         case 'actual':
-          compareScreenshots(
-            name,
-            getErrorThreshold(defaultScreenshotOptions, params)
-          );
+          compareScreenshots(name, {
+            ...screenshotOptions,
+            errorThreshold: getErrorThreshold(defaultScreenshotOptions, params),
+          });
 
           break;
 


### PR DESCRIPTION
* Useful when using Cypress retry for snapshot testing commands. By default there will be a diff on each retry attempt so if the test pass eventually, there still will be trashy diffs from previous attempts. With this argument and the knowledge of the try attempt number a bool condition could be crafted in the user code to allow diff creation only for the last retry attempt.

* Refactor in `compareScreenshots` to avoid code duplication around diff creation code

* Allow args passthrough to `compareScreenshots` plugin  from `compareScreenshots` command

* Introduce a new Cypress ENV NEVER_GENERATE_DIFF support in case if users want to permanently disable diffs creation for any reason