### PR TITLE
Restore onAfterScreenshot from the original API of `cy.screenshot`

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -33,6 +33,7 @@ function takeScreenshot(subject, name, screenshotOptions) {
   // save the path to forward between screenshot and move tasks
   function onAfterScreenshot(_doc, props) {
     screenshotPath = props.path;
+    screenshotOptions?.onAfterScreenshot?.(_doc, props)
   }
 
   objToOperateOn


### PR DESCRIPTION
* It generally is useful in many scenarios and this plugin is hiding it likely due to a oversight