### PR TITLE
fix: consider errorThreshold in commandOptions

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -52,6 +52,9 @@ function addCompareSnapshotCommand(screenshotOptions?: ScreenshotOptions): void 
       let errorThreshold = 0
       if (typeof commandOptions === 'object') {
         screenshotOptions = { ...screenshotOptions, ...commandOptions }
+        if (commandOptions.errorThreshold !== undefined) {
+          errorThreshold = commandOptions.errorThreshold
+        }
       }
       if (typeof commandOptions === 'number') {
         errorThreshold = commandOptions

--- a/src/command.ts
+++ b/src/command.ts
@@ -55,9 +55,10 @@ function addCompareSnapshotCommand(screenshotOptions?: ScreenshotOptions): void 
         if (commandOptions.errorThreshold !== undefined) {
           errorThreshold = commandOptions.errorThreshold
         }
-      }
-      if (typeof commandOptions === 'number') {
+      } else if (typeof commandOptions === 'number') {
         errorThreshold = commandOptions
+      } else if (screenshotOptions?.errorThreshold !== undefined) {
+        errorThreshold = screenshotOptions.errorThreshold
       }
 
       const visualRegressionOptions: VisualRegressionOptions = prepareOptions(name, errorThreshold, screenshotOptions)


### PR DESCRIPTION
The compareSnapshot task determines the errorThreshold as follows:

```js
      let errorThreshold = 0
      if (typeof commandOptions === 'object') {
        screenshotOptions = { ...screenshotOptions, ...commandOptions }
      }
      if (typeof commandOptions === 'number') {
        errorThreshold = commandOptions
      }
```

The `errorThreshold` is zero unless the second parameter to `compareSnapshot()` is a number. But if it is an object, the `errorThreshold` will be zero, regardless of what the value of `options.errorThreshold` is.

```js
// This will always use an errorThreshold of `0`, regardless what I set below:
cy.compareSnapshot('editor', {
  errorThreshold: 0.5,
  overwrite: true,
});
```

This PR tries to remedy this.