### PR TITLE
Fix import path in readme for TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you're using TypeScript, use files with a `.ts` extension, as follows:
 
 ```typescript
 import { defineConfig } from 'cypress'
-import { configureVisualRegression } from 'cypress-visual-regression'
+import { configureVisualRegression } from 'cypress-visual-regression/dist/plugin'
 
 export default defineConfig({
   e2e: {


### PR DESCRIPTION
Using the `cypress-visual-regression` import path caused `tsc` to report an error that `cypress-visual-regression` does not have this exported member.

```
Error: cypress.config.ts(2,10): error TS2305: Module '"cypress-visual-regression"' has no exported member 'configureVisualRegression'.
```

With the deep import path, this error disappears