### PR TITLE
Restore onAfterScreenshot from the original API of 'cy screenshot'

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -211,6 +211,7 @@ function takeScreenshot(
         ...screenshotOptions,
         onAfterScreenshot(_el, props) {
           ScreenshotDetails = props
+          screenshotOptions?.onAfterScreenshot?.(_el, props)
         }
       })
       // @ts-ignore


### PR DESCRIPTION
* It is useful in many scenarios and this plugin hides it likely due to an oversight

This is another push based on previous https://github.com/cypress-visual-regression/cypress-visual-regression/pull/201