### PR TITLE
Fixed overwriting errorThreshold value when no errorThreshold is specified when calling the compareSnapshot function.

### DIFF
--- a/cypress/e2e/main.cy.ts
+++ b/cypress/e2e/main.cy.ts
@@ -126,7 +126,7 @@ describe('Visual Regression Example', () => {
 
   it('should compare images of different sizes', () => {
     cy.on('fail', (error) => {
-      if (error.message.includes('The "bar-07" image is different. Threshold limit exceeded!')) {
+      if (error.message.includes('The "bar_07" image is different. Threshold limit exceeded!')) {
         return
       }
       throw error

--- a/src/command.ts
+++ b/src/command.ts
@@ -71,7 +71,9 @@ function addCompareSnapshotCommand(screenshotOptions?: ScreenshotOptions): void 
         }
       } else {
         regressionOptions = { ...screenshotOptions }
-        errorThreshold = commandOptions
+        if (commandOptions !== undefined) {
+          errorThreshold = commandOptions
+        }
       }
 
       const nameSanitized = name.replace(/[^a-z0-9]/gi, '_').toLowerCase()


### PR DESCRIPTION
Fixes #253