### PR TITLE
Extend pixelmatch options

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -32,7 +32,6 @@ settings:
 
 rules:
   '@typescript-eslint/ban-ts-comment': 'warn'
-  '@typescript-eslint/prefer-ts-expect-error': 'off'
   '@typescript-eslint/consistent-type-definitions': ['error', 'type']
   '@typescript-eslint/no-explicit-any': 'warn'
   '@typescript-eslint/no-invalid-void-type': 'off'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v5.2.0
+
+- Enable overriding pixelmatch options, fixes [#263](https://github.com/cypress-visual-regression/cypress-visual-regression/issues/263) and [#113](https://github.com/cypress-visual-regression/cypress-visual-regression/issues/113)
+- Move plugin options preparation logic to command.ts file
+- Refactor how options priority works: default < e2e file < env vars < command options
+
 ## v5.1.0
 
 - Add a show difference functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enable overriding pixelmatch options, fixes [#263](https://github.com/cypress-visual-regression/cypress-visual-regression/issues/263) and [#113](https://github.com/cypress-visual-regression/cypress-visual-regression/issues/113)
 - Move plugin options preparation logic to command.ts file
 - Refactor how options priority works: default < e2e file < env vars < command options
+- Update readme file describing the 'show difference' functionality
 
 ## v5.1.0
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![github actions](https://github.com/mjhea0/cypress-visual-regression/workflows/Continuous%20Integration/badge.svg)](https://github.com/mjhea0/cypress-visual-regression/actions)
 
-Module for adding visual regression testing to [Cypress](https://www.cypress.io/).
+Plugin for adding visual regression testing to [Cypress](https://www.cypress.io/).
 
 ## Installation
 
@@ -92,35 +92,45 @@ For more info on how to use TypeScript with Cypress, please refer to [this docum
 
 ## Plugin options
 
-All options can be configured within `visualRegression` namespace under `env` variable inside `cypress.config.js` file, like this:
+All options can be configured within `visualRegression` prefix under `env` variable inside `cypress.config.js` file, like this:
 
 ```javascript
-e2e: {
-  screenshotsFolder: './cypress/snapshots/actual',
-  env: {
-    visualRegressionType: 'regression',
-    visualRegressionBaseDirectory: 'cypress/snapshot/base',
-    visualRegressionDiffDirectory: 'cypress/snapshot/diff',
-    visualRegressionGenerateDiff: 'always',
-    visualRegressionFailSilently: true
+module.exports = defineConfig({
+  e2e: {
+    screenshotsFolder: './cypress/snapshots/actual',
+    env: {
+      visualRegressionType: 'regression',
+      visualRegressionBaseDirectory: 'cypress/snapshot/base',
+      visualRegressionDiffDirectory: 'cypress/snapshot/diff',
+      visualRegressionGenerateDiff: 'always',
+      visualRegressionFailSilently: true
+    }
   }
-}
+})
 ```
 
-| Variable                      | Default                 | Description                                                                                                                                                  |
-| ----------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| visualRegressionType          | /                       | Either 'regression' or 'base'. Base will override any existing base images with new screenshots. Regression will compare the base to the current screenshot. |
-| visualRegressionBaseDirectory | 'cypress/snapshot/base' | Path to the directory where the base snapshots will be stored.                                                                                               |
-| visualRegressionDiffDirectory | 'cypress/snapshot/diff' | Path to the directory where the generated image differences will be stored.                                                                                  |
-| visualRegressionGenerateDiff  | 'fail'                  | Either 'fail', 'never' or 'always'. Determines if and when image differences are generated.                                                                  |
-| visualRegressionFailSilently  | false                   | Used to decide if any error found in regression should be thrown or returned as part of the result.                                                          |
+| Variable                      | Default                  | Description                                                                                                                                                  |
+| ----------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| visualRegressionType          | /                        | Either 'regression' or 'base'. Base will override any existing base images with new screenshots. Regression will compare the base to the current screenshot. |
+| visualRegressionBaseDirectory | 'cypress/snapshots/base' | Path to the directory where the base snapshots will be stored.                                                                                               |
+| visualRegressionDiffDirectory | 'cypress/snapshots/diff' | Path to the directory where the generated image differences will be stored.                                                                                  |
+| visualRegressionGenerateDiff  | 'fail'                   | Either 'fail', 'never' or 'always'. Determines if and when image differences are generated.                                                                  |
+| visualRegressionFailSilently  | false                    | Used to decide if any error found in regression should be thrown or returned as part of the result.                                                          |
 
-You can also pass default cypress screenshot [arguments](https://docs.cypress.io/api/cypress-api/screenshot-api.html#Arguments) to `addCompareSnapshotCommand()`, like this:
+To override different default arguments/options on a global level pass them to the `addCompareSnapshotCommand()` command:
+
+- cypress screenshot [arguments](https://docs.cypress.io/api/cypress-api/screenshot-api.html#Arguments)
+- pixelmatch [options](https://github.com/mapbox/pixelmatch?tab=readme-ov-file#pixelmatchimg1-img2-output-width-height-options)
+- plugin configuration (errorThreshold, failSilently)
 
 ```javascript
 const { addCompareSnapshotCommand } = require('cypress-visual-regression/dist/command')
 addCompareSnapshotCommand({
-  capture: 'fullPage'
+  capture: 'fullPage', // cypress screenshot option
+  errorThreshold: 0.5, // plugin threshold option
+  pixelmatchOptions: {
+    threshold: 0 // pixelmatch threshold option
+  }
 })
 ```
 
@@ -136,11 +146,11 @@ cy.compareSnapshot(name, options)
 
 ### > arguments
 
-| Arguments      | Default | Description                                                                                                  |
-| -------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
-| name           | /       | Represents the name of the base snapshot file that the actual screenshot will be compared with.              |
-| errorThreshold | 0       | Threshold under which any image difference will be considered as failed test. Represented in percentages.    |
-| options        | {}      | Used to provide additional cypress screenshot options as well as `failSilently` and `errorThreshold` values. |
+| Arguments      | Default | Description                                                                                                                  |
+| -------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| name           | /       | Represents the name of the base snapshot file that the actual screenshot will be compared with.                              |
+| errorThreshold | 0       | Threshold under which any image difference will be considered as failed test. Represented in percentages.                    |
+| options        | {}      | Used to provide additional cypress screenshot arguments, pixelmatch options, and `failSilently` and `errorThreshold` values. |
 
 ### > examples
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 [![github actions](https://github.com/mjhea0/cypress-visual-regression/workflows/Continuous%20Integration/badge.svg)](https://github.com/mjhea0/cypress-visual-regression/actions)
 
-Plugin for adding visual regression testing to [Cypress](https://www.cypress.io/).
+Plugin that adds powerful visual regression testing capabilities to [Cypress](https://www.cypress.io/):
+
+![example](./cypress-visual-regression.gif)
 
 ## Installation
 
@@ -35,7 +37,7 @@ module.exports = defineConfig({
 })
 ```
 
-Pay attention to the `type` option. Use 'base' to generate baseline images, and 'regression' to compare current
+Pay attention to the `visualRegressionType` option. Use 'base' to generate baseline images, and 'regression' to compare current
 screenshot to the base screenshot
 
 In your support file _cypress/support/e2e.js_ add the following:
@@ -152,6 +154,18 @@ cy.compareSnapshot(name, options)
 | errorThreshold | 0       | Threshold under which any image difference will be considered as failed test. Represented in percentages.                    |
 | options        | {}      | Used to provide additional cypress screenshot arguments, pixelmatch options, and `failSilently` and `errorThreshold` values. |
 
+### > yields
+
+- `.compareSnapshot()` yields the Visual Regression Result object which contains the following info:
+
+| Result           | Type               | Description                                                                                                  |
+| ---------------- | ------------------ | ------------------------------------------------------------------------------------------------------------ |
+| error            | string (optional)  | Contains visual regression error message                                                                     |
+| images           | object             | Contains `base64` string of generated images for `actual`, `base` (optional) and `diff` (optional) images    |
+| baseGenerated    | boolean (optional) | Set to `true` if visual regression plugin was run for base generation (`visualRegressionType` set to 'base') |
+| mismatchedPixels | number (optional)  | Represents the number of total mismatched pixels during visual comparison. Set if difference were discovered |
+| percentage       | number (optional)  | Represents the difference between the images in percentage. Set if difference were discovered                |
+
 ### > examples
 
 ```TypeScript
@@ -167,10 +181,6 @@ cy.compareSnapshot('homePage', {errorThreshold: 1, failSilently: true}).then(com
 ```
 
 > Looking for more examples? See [cypress/e2e/main.cy.ts](https://github.com/cypress-visual-regression/cypress-visual-regression/blob/master/cypress/e2e/main.cy.ts).
-
-## Example
-
-![example](./cypress-visual-regression.gif)
 
 ## Tips & Tricks
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-visual-regression",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-visual-regression",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -4613,12 +4613,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-visual-regression",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Module for adding visual regression testing to Cypress",
   "keywords": [
     "visual regression",
@@ -65,7 +65,6 @@
   },
   "ignore": [
     "src",
-    "docker",
     "tests"
   ],
   "overrides": {

--- a/src/command.ts
+++ b/src/command.ts
@@ -214,7 +214,7 @@ function takeScreenshot(
 
 /** Call the plugin to compare snapshot images and generate a diff */
 function compareScreenshots(
-  subject: Cypress.JQueryWithSelector<HTMLElement> | void,
+  subject: Cypress.JQueryWithSelector | void,
   options: VisualRegressionOptions
 ): Cypress.Chainable<VisualRegressionResult> {
   return cy.task<VisualRegressionResult>('compareSnapshots', options, { log: false }).then((result) => {
@@ -272,7 +272,7 @@ function compareScreenshots(
 
 /** Call the plugin to update base snapshot images */
 function updateSnapshots(
-  subject: Cypress.JQueryWithSelector<HTMLElement> | void,
+  subject: Cypress.JQueryWithSelector | void,
   options: VisualRegressionOptions
 ): Cypress.Chainable<VisualRegressionResult> {
   return cy.task<VisualRegressionResult>('updateSnapshot', options, { log: false }).then((result) => {

--- a/tests/cjs/package-lock.json
+++ b/tests/cjs/package-lock.json
@@ -11,11 +11,11 @@
         "cypress-visual-regression": "../../../cypress-visual-regression"
       },
       "peerDependencies": {
-        "cypress": ">=12"
+        "cypress": "13.13.3"
       }
     },
     "../..": {
-      "version": "5.0.3",
+      "version": "5.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -578,13 +578,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
-      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -623,7 +624,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/tests/cjs/package.json
+++ b/tests/cjs/package.json
@@ -9,6 +9,6 @@
     "cypress-visual-regression": "../../../cypress-visual-regression"
   },
   "peerDependencies": {
-    "cypress": ">=12"
+    "cypress": "13.13.3"
   }
 }

--- a/tests/esm/package-lock.json
+++ b/tests/esm/package-lock.json
@@ -11,11 +11,11 @@
         "cypress-visual-regression": "../../../cypress-visual-regression"
       },
       "peerDependencies": {
-        "cypress": ">=12"
+        "cypress": "13.13.3"
       }
     },
     "../..": {
-      "version": "5.0.2",
+      "version": "5.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -578,13 +578,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
-      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -623,7 +624,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/tests/esm/package.json
+++ b/tests/esm/package.json
@@ -10,6 +10,6 @@
     "cypress-visual-regression": "../../../cypress-visual-regression"
   },
   "peerDependencies": {
-    "cypress": ">=12"
+    "cypress": "13.13.3"
   }
 }

--- a/tests/integration/cypress/e2e/main.cy.ts
+++ b/tests/integration/cypress/e2e/main.cy.ts
@@ -202,8 +202,15 @@ describe('Visual Regression Example', () => {
     })
     cy.on('log:added', (attr) => {
       if (attr.name === 'compareScreenshots') {
-        const options = attr.consoleProps.props.Options
-        const result = attr.consoleProps.props.Result
+        let options: any, result: any
+        const cypressVersion = Number.parseInt(Cypress.version.match(/^\d+/)[0])
+        if (cypressVersion <= 12) {
+          options = attr.consoleProps.Options
+          result = attr.consoleProps.Result
+        } else {
+          options = attr.consoleProps.props.Options
+          result = attr.consoleProps.props.Result
+        }
         expect(options.baseDirectory).to.equal('cypress/snapshots/base')
         expect(options.diffDirectory).to.equal('cypress/snapshots/diff')
         expect(options.pluginOptions.errorThreshold).to.equal(0)

--- a/tests/integration/cypress/e2e/main.env.cy.ts
+++ b/tests/integration/cypress/e2e/main.env.cy.ts
@@ -1,12 +1,10 @@
-import { CypressConfigEnv } from '@src/command'
-
 const visualRegressionConfig = Cypress.env()
 
 visualRegressionConfig.baseDirectory = './cypress/snapshots/alternative-base'
 visualRegressionConfig.diffDirectory = './cypress/snapshots/alternative-diff'
 visualRegressionConfig.generateDiff = 'always'
 
-const env: Partial<CypressConfigEnv> = {
+const env: any = {
   ...Cypress.env(),
   visualRegressionBaseDirectory: './cypress/snapshots/alternative-base',
   visualRegressionDiffDirectory: './cypress/snapshots/alternative-diff',
@@ -20,26 +18,21 @@ describe(
   },
   () => {
     it('take screenshot with parent command', () => {
+      cy.visit('./cypress/web/01.html')
+      cy.get('H1').contains('Hello, World')
+      cy.compareSnapshot('home')
       if (env.visualRegressionType === 'base') {
-        cy.visit('./cypress/web/01.html')
-        cy.get('H1').contains('Hello, World')
-        cy.compareSnapshot('home')
         cy.readFile(`${env.visualRegressionBaseDirectory}/cypress/e2e/main.env.cy.ts/home.png`).should('exist')
       } else {
-        cy.visit('./cypress/web/01.html')
-        cy.get('H1').contains('Hello, World')
-        cy.compareSnapshot('home')
         cy.readFile(`${env.visualRegressionDiffDirectory}/cypress/e2e/main.env.cy.ts/home.png`).should('exist')
       }
     })
     it('take screenshot with child command', () => {
+      cy.visit('./cypress/web/01.html')
+      cy.get('H1').contains('Hello, World').compareSnapshot('home-child')
       if (env.visualRegressionType === 'base') {
-        cy.visit('./cypress/web/01.html')
-        cy.get('H1').contains('Hello, World').compareSnapshot('home-child')
         cy.readFile(`${visualRegressionConfig.baseDirectory}/cypress/e2e/main.env.cy.ts/home-child.png`).should('exist')
       } else {
-        cy.visit('./cypress/web/01.html')
-        cy.get('H1').contains('Hello, World').compareSnapshot('home-child')
         cy.readFile(`${visualRegressionConfig.diffDirectory}/cypress/e2e/main.env.cy.ts/home-child.png`).should('exist')
       }
     })

--- a/tests/integration/cypress/support/e2e.ts
+++ b/tests/integration/cypress/support/e2e.ts
@@ -1,2 +1,9 @@
 import { addCompareSnapshotCommand } from 'cypress-visual-regression/dist/command'
-addCompareSnapshotCommand()
+addCompareSnapshotCommand({
+  pixelmatchOptions: {
+    threshold: 0.1
+  },
+  errorThreshold: 0,
+  failSilently: false,
+  capture: 'fullPage'
+})

--- a/tests/integration/cypress/web/pixelmatch.html
+++ b/tests/integration/cypress/web/pixelmatch.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Base</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="first" style="color: #810080ff">Color</h1>
+      <h1 id="second" style="color: #800080ff">Color</h1>
+    </div>
+  </body>
+</html>

--- a/tests/integration/cypress/web/random.html
+++ b/tests/integration/cypress/web/random.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Base</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+  </head>
+  <body>
+    <div class="container">
+      <h1 id="random">Hello, World!</h1>
+    </div>
+  </body>
+  <script>
+    document.getElementById('random').innerHTML = Math.random().toString()
+  </script>
+</html>

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -17,7 +17,7 @@
       }
     },
     "../..": {
-      "version": "5.0.4",
+      "version": "5.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4551,9 +4551,9 @@
       "peer": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/integration/package-lock.json
+++ b/tests/integration/package-lock.json
@@ -13,11 +13,11 @@
         "ts-loader": "^9.5.1"
       },
       "peerDependencies": {
-        "cypress": ">=12"
+        "cypress": "13.13.3"
       }
     },
     "../..": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2610,9 +2610,9 @@
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.1.tgz",
+      "integrity": "sha512-u5w79Rd7SU4JaIlA/zFqG+gOiuq25q5VLyZ8E+ijJeILuTxVzZgp2CaGw/UTw6pXYN9XMO9yiqj/nEHmhTG5CA==",
       "license": "MIT",
       "peer": true
     },
@@ -3096,14 +3096,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.0.tgz",
-      "integrity": "sha512-ou/MQUDq4tcDJI2FsPaod2FZpex4kpIK43JJlcBgWrX8WX7R/05ZxGTuxedOuZBfxjZxja+fbijZGyxiLP6CFA==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -10,7 +10,7 @@
     "cy:regression": "cypress run -C cypress.regression.config.ts"
   },
   "peerDependencies": {
-    "cypress": ">=12"
+    "cypress": "13.13.3"
   },
   "devDependencies": {
     "cypress-visual-regression": "../../../cypress-visual-regression",

--- a/tests/ts-alt/package-lock.json
+++ b/tests/ts-alt/package-lock.json
@@ -12,11 +12,11 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "cypress": ">=12"
+        "cypress": "13.13.3"
       }
     },
     "../..": {
-      "version": "5.0.2",
+      "version": "5.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -576,13 +576,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
-      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -621,7 +622,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/tests/ts-alt/package.json
+++ b/tests/ts-alt/package.json
@@ -10,6 +10,6 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "cypress": ">=12"
+    "cypress": "13.13.3"
   }
 }

--- a/tests/ts/package-lock.json
+++ b/tests/ts/package-lock.json
@@ -12,11 +12,11 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "cypress": ">=12"
+        "cypress": "13.13.3"
       }
     },
     "../..": {
-      "version": "5.0.2",
+      "version": "5.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -576,13 +576,14 @@
       }
     },
     "node_modules/cypress": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.9.0.tgz",
-      "integrity": "sha512-atNjmYfHsvTuCaxTxLZr9xGoHz53LLui3266WWxXJHY7+N6OdwJdg/feEa3T+buez9dmUXHT1izCOklqG82uCQ==",
+      "version": "13.13.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.3.tgz",
+      "integrity": "sha512-hUxPrdbJXhUOTzuML+y9Av7CKoYznbD83pt8g3klgpioEha0emfx4WNIuVRx0C76r0xV2MIwAW9WYiXfVJYFQw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -621,7 +622,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },

--- a/tests/ts/package.json
+++ b/tests/ts/package.json
@@ -11,6 +11,6 @@
     "typescript": "^5.4.5"
   },
   "peerDependencies": {
-    "cypress": ">=12"
+    "cypress": "13.13.3"
   }
 }


### PR DESCRIPTION
This PR will:

- enable overriding default pixelmatch options, like threshold (fixes #113 and #263 
- moved plugin options preparation logic to `command.ts` file and cleaned it up. The logic on which it works now is: set default values, then override values set in e2e file, then override values set in env variables, then lastly override any options set in the command itself
- extended tests to check this logic
- minor other improvements