### PR TITLE
Adjust diff screenshot name according cypress retry attempt

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -180,7 +180,9 @@ function compareScreenshots(
   subject: Cypress.JQueryWithSelector | void,
   options: VisualRegressionOptions
 ): Cypress.Chainable<VisualRegressionResult> {
-  return cy.task<VisualRegressionResult>('compareSnapshots', options, { log: false }).then((result) => {
+  const retryAttempt = Cypress.currentRetry
+  const compareSnapshotsOptions = { retryAttempt, ...options }
+  return cy.task<VisualRegressionResult>('compareSnapshots', compareSnapshotsOptions, { log: false }).then((result) => {
     const log = Cypress.log({
       type: 'parent',
       name: 'compareScreenshots',

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -75,8 +75,11 @@ export const updateSnapshot = async (options: UpdateSnapshotOptions): Promise<Vi
  * Cypress plugin to compare image snapshots & generate a diff image.
  * Uses the pixelmatch library internally.
  * */
-export const compareSnapshots = async (options: VisualRegressionOptions): Promise<VisualRegressionResult> => {
+export const compareSnapshots = async (
+  options: VisualRegressionOptions & { retryAttempt: number }
+): Promise<VisualRegressionResult> => {
   const sanitizedFileName = sanitize(options.screenshotName)
+  const retryAttempt = options.retryAttempt
 
   const expectedImagePath = path.join(options.baseDirectory, options.spec.relative, `${sanitizedFileName}.png`)
   if (!existsSync(expectedImagePath)) {
@@ -89,7 +92,10 @@ export const compareSnapshots = async (options: VisualRegressionOptions): Promis
   const actualImageBuffer = readFileSync(actualImagePath)
   const actualImage = PNG.sync.read(actualImageBuffer)
 
-  const diffImagePath = path.join(options.diffDirectory, options.spec.relative, `${sanitizedFileName}.png`)
+  const diffFileName =
+    retryAttempt > 0 ? `${sanitizedFileName} (attempt ${retryAttempt + 1}).png` : `${sanitizedFileName}.png`
+
+  const diffImagePath = path.join(options.diffDirectory, options.spec.relative, diffFileName)
   const diffImage = new PNG({
     width: Math.max(actualImage.width, expectedImage.width),
     height: Math.max(actualImage.height, expectedImage.height)


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX19JjUmtS51FvfeJCsvqEMpWbXL5PAqds%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=PcJu8f9)

Cypress supports test retries. I noticed that actual screenshots have different names for each attempt, but diff screenshots do not. The same diff screenshot will be overridden each test run attempt. I believe it's a good idea to save all diffs according to the Cypress approach (with the additional `(attempt ...)` part).
Doc: https://docs.cypress.io/app/guides/test-retries